### PR TITLE
Add object creation syntax to analyzer

### DIFF
--- a/RequireNamedArgs.Tests/Support/DiagnosticMatcher.fs
+++ b/RequireNamedArgs.Tests/Support/DiagnosticMatcher.fs
@@ -50,9 +50,12 @@ module Expect =
         let expectCountsToMatch() = 
             let expectedCount = expected |> Seq.length
             let actualCount = actual |> Seq.length
+            let mutable diagString = ""
+            for d in actual do 
+               diagString <- diagString + d.ToString()
             Expect.isTrue (expectedCount = actualCount)
-                          (sprintf "Mismatch between number of diagnostics returned, expected \"%d\" actual \"%d\"\r\n\r\nDiagnostics:\r\n%s\r\n"
-                                   expectedCount actualCount (if Seq.any actual then analyzer.Format actual else "    NONE."))
+                          (sprintf "Mismatch between number of diagnostics returned, expected \"%d\" actual \"%d\"\r\n\r\nDiagnostics:\r\n%s: %s\r\n"
+                                   expectedCount actualCount diagString (if Seq.any actual then analyzer.Format actual else "    NONE."))
 
         let expectDiagsToMatch (expected: DiagResult, actual: Diagnostic) =
             let describeDiag() = analyzer.Format [actual]

--- a/RequireNamedArgs/Analysis/InvocationExprSyntax.fs
+++ b/RequireNamedArgs/Analysis/InvocationExprSyntax.fs
@@ -37,8 +37,8 @@ let private getArgAndParams
     Seq.foldBack folder syntaxAndMaybeInfos (Some [])
 
 let private namedArgsRequired (sema: SemanticModel) 
-                              (invocationExprSyntax: InvocationExpressionSyntax) =
-    let methodSymbolOpt = sema.GetSymbolInfo(invocationExprSyntax).Symbol |> Option.ofType<IMethodSymbol>
+                              (exprSyntax: ExpressionSyntax) =
+    let methodSymbolOpt = sema.GetSymbolInfo(exprSyntax).Symbol |> Option.ofType<IMethodSymbol>
     match methodSymbolOpt with
     | None -> false
     | Some methodSymbol ->
@@ -56,15 +56,19 @@ let private namedArgsRequired (sema: SemanticModel)
 /// </returns>
 let getArgsWhichShouldBeNamed 
     (sema: SemanticModel) 
-    (invocationExprSyntax: InvocationExpressionSyntax) =
+    (exprSyntax: ExpressionSyntax) =
     let NoArgsShouldBeNamed = []
-    let argSyntaxes = invocationExprSyntax.ArgumentList.Arguments
     maybe {
+        let argSyntaxes = match exprSyntax with 
+            | :? InvocationExpressionSyntax as i -> i.ArgumentList.Arguments
+            | :? ObjectCreationExpressionSyntax as o -> o.ArgumentList.Arguments
+            | _ -> new SeparatedSyntaxList<ArgumentSyntax>()
+
         if Seq.isEmpty argSyntaxes 
         then return NoArgsShouldBeNamed 
         else
 
-        if not (namedArgsRequired sema invocationExprSyntax) 
+        if not (namedArgsRequired sema exprSyntax) 
         then return NoArgsShouldBeNamed 
         else
 

--- a/RequireNamedArgs/RequireNamedArgsAnalyzer.fs
+++ b/RequireNamedArgs/RequireNamedArgsAnalyzer.fs
@@ -59,14 +59,14 @@ type public RequireNamedArgsAnalyzer() =
 
     member private this.Analyze(context: SyntaxNodeAnalysisContext) =
         maybe {
-            let! invocationExprSyntax = context.Node |> Option.ofType<InvocationExpressionSyntax>
-            let! methodSymbol = context.SemanticModel.GetSymbolInfo(invocationExprSyntax).Symbol 
+            let! exprSyntax = context.Node |> Option.ofType<ExpressionSyntax>
+            let! methodSymbol = context.SemanticModel.GetSymbolInfo(exprSyntax).Symbol 
                                 |> Option.ofType<IMethodSymbol>
             let! methodSymbol = methodSymbol |> this.filterSupported
             // We got a supported kind of method.
             // Delegate heavy-lifting to the call below.
             let! argsWhichShouldBeNamed = getArgsWhichShouldBeNamed context.SemanticModel 
-                                                                    invocationExprSyntax
+                                                                    exprSyntax
 
             // We inspected the arguments of invocation expression.
             if argsWhichShouldBeNamed |> Seq.any 
@@ -74,7 +74,7 @@ type public RequireNamedArgsAnalyzer() =
                  return context.ReportDiagnostic(
                      Diagnostic.Create(
                          descriptor, 
-                         invocationExprSyntax.GetLocation(),
+                         exprSyntax.GetLocation(),
                          // messageArgs
                          methodSymbol.Name, 
                          this.formatDiagMessage argsWhichShouldBeNamed))


### PR DESCRIPTION
This adds support for calling constructors with RequireNamedArgs properties.

Fixes #2 